### PR TITLE
Fix Search in Layer not performing a search after Layer process has been terminated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1 & 0.1.2 - Hotfixes
+* Fixed a bug that would prevent the Layer desktop app performing a search when clicking the Search in Layer button after the Layer process has been terminated (#3)
+* Updated package keywords
+
 ## 0.1.0 - First Official Release
 ### New features <small>- Introducing the Better Git Blame gutter view!</small>
 * Toggle gutter with `ctrl-b` to display `git blame` data

--- a/lib/stepsize/StepsizeHelper.ts
+++ b/lib/stepsize/StepsizeHelper.ts
@@ -68,7 +68,7 @@ class StepsizeHelper {
     });
   }
 
-  public static checkLayerInstallation() {
+  public static checkLayerInstallation() : Promise<void> {
     return new Promise((resolve, reject) => {
       childProcess.exec(
         "ls | grep 'Layer.app'",
@@ -81,6 +81,21 @@ class StepsizeHelper {
         }
       );
     });
+  }
+
+  public static checkLayerRunning() : Promise<void> {
+    return new Promise((resolve, reject) => {
+      childProcess.exec(
+        "pgrep Layer",
+        { cwd: '/' },
+        err => {
+          if (err) {
+            return reject(new Error('No process with name \'Layer\' is running'));
+          }
+          resolve();
+        }
+      );
+    })
   }
 
   /**

--- a/lib/stepsize/StepsizeOutgoing.ts
+++ b/lib/stepsize/StepsizeOutgoing.ts
@@ -57,23 +57,26 @@ class StepsizeOutgoing {
   }
 
   public send(event, callback?) {
-    if (!this.layerReady && event.type !== 'ready') {
-      this.checkLayerIsReady();
-      this.cachedMessage = event;
-      if (callback) {
-        callback();
+    StepsizeHelper.checkLayerRunning().then(() => {
+      let msg = JSON.stringify(event);
+      this.OUTGOING_SOCK.send(
+        msg,
+        0,
+        msg.length,
+        this.UDP_PORT,
+        this.UDP_HOST,
+        callback
+      );
+    }).catch(() => {
+      this.layerReady = false;
+      if (event.type !== 'ready') {
+        this.checkLayerIsReady();
+        this.cachedMessage = event;
+        if (callback) {
+          callback();
+        }
       }
-      return;
-    }
-    let msg = JSON.stringify(event);
-    this.OUTGOING_SOCK.send(
-      msg,
-      0,
-      msg.length,
-      this.UDP_PORT,
-      this.UDP_HOST,
-      callback
-    );
+    });
   }
 
   sendReady() {


### PR DESCRIPTION
Relates to Issue #3 

Added a new function to check that Layer is running, this is then called when sending messages over the UDP socket, if Layer is not running its ready state is set to false and it behaves like first launch.