### PR TITLE
Fix errors being thrown if a global email cannot be fetched from git config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 /lib export-ignore
+rollup.config.js export-ignore
+tsconfig.json export-ignore
 yarn.lock export-ignore
 .prettierrc export-ignore
 .gitattributes export-ignore

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -17360,7 +17360,7 @@ class StepsizeOutgoing {
     sendReady() {
         const event = {
             type: 'ready',
-            source: { name: 'BetterGitBlame', version: '0.1.0' },
+            source: { name: 'BetterGitBlame', version: version },
         };
         this.send(event);
     }
@@ -24339,7 +24339,6 @@ class TooltipPortal extends index.Component {
 
 'use babel';
 function runGitCommand(repoPath, command, shell = false) {
-    throw new Error('LOL');
     return new Promise((resolve, reject) => {
         const args = command.split(' ');
         const child = childProcess.spawn('git', args, { cwd: repoPath, shell });

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -17286,6 +17286,10 @@ class StepsizeHelper {
     }
 }
 
+var name = "better-git-blame";
+
+var version = "0.1.3";
+
 'use babel';
 class StepsizeOutgoing {
     constructor() {
@@ -17305,7 +17309,7 @@ class StepsizeOutgoing {
             };
             this.send(event);
         };
-        this.pluginId = 'atom_v0.1.3';
+        this.pluginId = `atom_v${version}`;
         this.DEBUG = false;
         this.UDP_HOST = '127.0.0.1';
         this.UDP_PORT = 49369;
@@ -19203,7 +19207,7 @@ function render(vnode, parent, merge) {
   return diff(merge, vnode, {}, false, parent, false);
 }
 
-var version = '15.1.0'; // trick libraries to think we are react
+var version$1 = '15.1.0'; // trick libraries to think we are react
 
 var ELEMENTS = 'a abbr address area article aside audio b base bdi bdo big blockquote body br button canvas caption cite code col colgroup data datalist dd del details dfn dialog div dl dt em embed fieldset figcaption figure footer form h1 h2 h3 h4 h5 h6 head header hgroup hr html i iframe img input ins kbd keygen label legend li link main map mark menu menuitem meta meter nav noscript object ol optgroup option output p param picture pre progress q rp rt ruby s samp script section select small source span strong style sub summary sup table tbody td textarea tfoot th thead time title tr track u ul var video wbr circle clipPath defs ellipse g image line linearGradient mask path pattern polygon polyline radialGradient rect stop svg text tspan'.split(' ');
 
@@ -19810,7 +19814,7 @@ PureComponent.prototype.shouldComponentUpdate = function(props, state) {
 };
 
 var index = {
-	version: version,
+	version: version$1,
 	DOM: DOM,
 	PropTypes: propTypes,
 	Children: Children,
@@ -24381,7 +24385,7 @@ function email() {
 }
 
 'use babel';
-const packageName = 'better-git-blame';
+const packageName = name;
 const config$1 = {
     defaultWidth: {
         title: 'Gutter width (px)',
@@ -25178,7 +25182,7 @@ function isPromise(obj) {
 
 
 
-var main = function (adapter) {
+var main$1 = function (adapter) {
   if (typeof adapter !== 'object') {
     throw new Error('An adapter must be provided, see https://github.com/typicode/lowdb/#usage');
   }
@@ -25294,7 +25298,7 @@ var Memory = function (_Base) {
 
 'use babel';
 const adapter = new Memory();
-const db = main(adapter);
+const db = main$1(adapter);
 db
     .defaults({
     commitMessages: {},

--- a/lib/ConfigManager.ts
+++ b/lib/ConfigManager.ts
@@ -1,5 +1,8 @@
 'use babel';
-const packageName = 'better-git-blame';
+
+import { name } from '../package.json'
+const packageName = name;
+
 export const config = {
   defaultWidth: {
     title: 'Gutter width (px)',

--- a/lib/stepsize/Analytics.ts
+++ b/lib/stepsize/Analytics.ts
@@ -53,7 +53,13 @@ async function segmentRequest(path, body): Promise<any> {
 
 export async function init() {
   if (ConfigManager.get('sendUsageStatistics')) {
-    let userEmail = await email();
+    let userEmail;
+    try {
+      userEmail = await email();
+    } catch(e){
+      console.error(e)
+    }
+    if (!userEmail) return;
     const hash = crypto.createHash('sha256');
     hash.update(userEmail);
     userHash = hash.digest('hex');
@@ -82,7 +88,7 @@ export async function init() {
 }
 
 export function track(name, data = {}) {
-  if (ConfigManager.get('sendUsageStatistics')) {
+  if (ConfigManager.get('sendUsageStatistics') && userHash) {
     segmentRequest('/track', {
       event: `BGB ${name}`,
       userId: userHash,

--- a/lib/stepsize/StepsizeOutgoing.ts
+++ b/lib/stepsize/StepsizeOutgoing.ts
@@ -83,7 +83,7 @@ class StepsizeOutgoing {
   sendReady() {
     const event = {
       type: 'ready',
-      source: { name: 'BetterGitBlame', version: '0.1.0' },
+      source: { name: 'BetterGitBlame', version: version },
     };
     this.send(event);
   }

--- a/lib/stepsize/StepsizeOutgoing.ts
+++ b/lib/stepsize/StepsizeOutgoing.ts
@@ -4,6 +4,7 @@ import { Socket, createSocket } from 'dgram';
 import fs from 'fs';
 import StepsizeHelper from './StepsizeHelper';
 import Timer = NodeJS.Timer;
+import { version } from '../../package.json';
 
 class StepsizeOutgoing {
   private pluginId;
@@ -18,7 +19,7 @@ class StepsizeOutgoing {
   private cachedMessage: any;
 
   constructor() {
-    this.pluginId = 'atom_v0.1.3';
+    this.pluginId = `atom_v${version}`;
     this.DEBUG = false;
     this.UDP_HOST = '127.0.0.1';
     this.UDP_PORT = 49369;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,8 @@ export default {
   input: 'lib/index.ts',
   output: {
     file: 'dist/bundle.js',
-    format: 'cjs'
+    format: 'cjs',
+    sourcemap: false
   },
   external: ['https', 'atom', 'dgram', 'fs', 'child_process', 'crypto', 'path', 'os'],
   plugins: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,8 @@
     "preserveConstEnums": true,
     "reactNamespace": "React",
     "skipLibCheck": true,
-    "inlineSourceMap": false,
-    "inlineSources": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "target": "ES6"
   }


### PR DESCRIPTION
Errors were being thrown when attempting to fetch values from git config ( Re: #5 )

Modified the runGitCommand function to reject the promise instead of throw if an error occurs in the child process.

Changed the Analytics functions to disable tracking if we cannot generate a hash for the user.