### PR TITLE
Fix issues causing Layer to perform multiple searches

### DIFF
--- a/lib/ConfigManager.ts
+++ b/lib/ConfigManager.ts
@@ -1,6 +1,6 @@
 'use babel';
 
-import { name } from '../package.json'
+import { name } from '../package.json';
 const packageName = name;
 
 export const config = {

--- a/lib/git/runCommand.ts
+++ b/lib/git/runCommand.ts
@@ -19,7 +19,9 @@ function runGitCommand(
     child.on('exit', exitCode => {
       if (exitCode !== 0 && exitCode !== 128) {
         console.error(command);
-        return reject(new Error(`Git exited with unexpected code: ${exitCode}`));
+        return reject(
+          new Error(`Git exited with unexpected code: ${exitCode}`)
+        );
       }
     });
 

--- a/lib/stepsize/Analytics.ts
+++ b/lib/stepsize/Analytics.ts
@@ -56,8 +56,8 @@ export async function init() {
     let userEmail;
     try {
       userEmail = await email();
-    } catch(e){
-      console.error(e)
+    } catch (e) {
+      console.error(e);
     }
     if (!userEmail) return;
     const hash = crypto.createHash('sha256');

--- a/lib/stepsize/StepsizeHelper.ts
+++ b/lib/stepsize/StepsizeHelper.ts
@@ -68,7 +68,7 @@ class StepsizeHelper {
     });
   }
 
-  public static checkLayerInstallation() : Promise<void> {
+  public static checkLayerInstallation(): Promise<void> {
     return new Promise((resolve, reject) => {
       childProcess.exec(
         "ls | grep 'Layer.app'",
@@ -83,19 +83,15 @@ class StepsizeHelper {
     });
   }
 
-  public static checkLayerRunning() : Promise<void> {
+  public static checkLayerRunning(): Promise<void> {
     return new Promise((resolve, reject) => {
-      childProcess.exec(
-        "pgrep Layer",
-        { cwd: '/' },
-        err => {
-          if (err) {
-            return reject(new Error('No process with name \'Layer\' is running'));
-          }
-          resolve();
+      childProcess.exec('pgrep Layer', { cwd: '/' }, err => {
+        if (err) {
+          return reject(new Error("No process with name 'Layer' is running"));
         }
-      );
-    })
+        resolve();
+      });
+    });
   }
 
   /**

--- a/lib/stepsize/StepsizeOutgoing.ts
+++ b/lib/stepsize/StepsizeOutgoing.ts
@@ -32,6 +32,7 @@ class StepsizeOutgoing {
         parsedMessage.source.name === 'Layer'
       ) {
         this.layerReady = true;
+        this.readyTries = 1;
         if (this.cachedMessage) {
           this.send(this.cachedMessage);
           this.cachedMessage = null;

--- a/lib/stepsize/StepsizeOutgoing.ts
+++ b/lib/stepsize/StepsizeOutgoing.ts
@@ -34,6 +34,7 @@ class StepsizeOutgoing {
         this.layerReady = true;
         if (this.cachedMessage) {
           this.send(this.cachedMessage);
+          this.cachedMessage = null;
         }
         clearInterval(this.readyInterval);
       }
@@ -58,26 +59,28 @@ class StepsizeOutgoing {
   }
 
   public send(event, callback?) {
-    StepsizeHelper.checkLayerRunning().then(() => {
-      let msg = JSON.stringify(event);
-      this.OUTGOING_SOCK.send(
-        msg,
-        0,
-        msg.length,
-        this.UDP_PORT,
-        this.UDP_HOST,
-        callback
-      );
-    }).catch(() => {
-      this.layerReady = false;
-      if (event.type !== 'ready') {
-        this.checkLayerIsReady();
-        this.cachedMessage = event;
-        if (callback) {
-          callback();
+    StepsizeHelper.checkLayerRunning()
+      .then(() => {
+        let msg = JSON.stringify(event);
+        this.OUTGOING_SOCK.send(
+          msg,
+          0,
+          msg.length,
+          this.UDP_PORT,
+          this.UDP_HOST,
+          callback
+        );
+      })
+      .catch(() => {
+        this.layerReady = false;
+        if (event.type !== 'ready') {
+          this.cachedMessage = event;
+          this.checkLayerIsReady();
+          if (callback) {
+            callback();
+          }
         }
-      }
-    });
+      });
   }
 
   sendReady() {


### PR DESCRIPTION
Re-worked some of StepsizeOutgoing to prevent Layer doing multiple searches when using the Search in Layer functionality.

Also added a debounce on the click events to stop events being fired more than once & Fixed the ready message back-off becoming too large with long user sessions