### PR TITLE
Notify users of integrations (once) if/when appropriate

### DIFF
--- a/lib/components/GutterItem.tsx
+++ b/lib/components/GutterItem.tsx
@@ -124,8 +124,7 @@ class GutterItem extends React.Component<IGutterItemProps, any> {
 
   tooltip() {
     const commitedDate = moment(this.state.commit.commitedAt).format('D MMM');
-    const { pullRequests, githubIssues, jiraIssues } = this.state;
-    IntegrationNotification.trackTooltipShown(pullRequests.length, githubIssues.length + jiraIssues.length);
+    IntegrationNotification.trackTooltipShown();
     return (
       <div className="layer-tooltip">
         <div className="section">
@@ -153,7 +152,7 @@ class GutterItem extends React.Component<IGutterItemProps, any> {
               </span>
           </div>
         </div>
-        {pullRequests.map((pullRequest) => {
+        {this.state.pullRequests.map((pullRequest) => {
           const verb = pullRequest.state.toLowerCase();
           return (
             <div className="section">
@@ -181,7 +180,7 @@ class GutterItem extends React.Component<IGutterItemProps, any> {
             </div>
           )
         })}
-        {githubIssues.map((issue) => {
+        {this.state.githubIssues.map((issue) => {
           let issueIcon = 'icon icon-issue-opened green';
           if(issue.state === 'CLOSED'){
             issueIcon = 'icon icon-issue-closed red'
@@ -206,7 +205,7 @@ class GutterItem extends React.Component<IGutterItemProps, any> {
             </div>
           )
         })}
-        {jiraIssues.map((issue) => {
+        {this.state.jiraIssues.map((issue) => {
           return (
             <div className="section">
               <div className="section-icon">

--- a/lib/components/GutterItem.tsx
+++ b/lib/components/GutterItem.tsx
@@ -11,6 +11,7 @@ import SearchInLayer from './SearchInLayer';
 import * as ConfigManager from '../ConfigManager';
 import BuildStatus from './BuildStatus';
 import * as Analytics from '../stepsize/Analytics';
+import * as IntegrationNotification from '../interface/IntegrationNotification';
 
 interface IGutterItemProps {
   commit: any;
@@ -123,6 +124,8 @@ class GutterItem extends React.Component<IGutterItemProps, any> {
 
   tooltip() {
     const commitedDate = moment(this.state.commit.commitedAt).format('D MMM');
+    const { pullRequests, githubIssues, jiraIssues } = this.state;
+    IntegrationNotification.trackTooltipShown(pullRequests.length, githubIssues.length + jiraIssues.length);
     return (
       <div className="layer-tooltip">
         <div className="section">
@@ -150,7 +153,7 @@ class GutterItem extends React.Component<IGutterItemProps, any> {
               </span>
           </div>
         </div>
-        {this.state.pullRequests.map((pullRequest) => {
+        {pullRequests.map((pullRequest) => {
           const verb = pullRequest.state.toLowerCase();
           return (
             <div className="section">
@@ -178,7 +181,7 @@ class GutterItem extends React.Component<IGutterItemProps, any> {
             </div>
           )
         })}
-        {this.state.githubIssues.map((issue) => {
+        {githubIssues.map((issue) => {
           let issueIcon = 'icon icon-issue-opened green';
           if(issue.state === 'CLOSED'){
             issueIcon = 'icon icon-issue-closed red'
@@ -203,7 +206,7 @@ class GutterItem extends React.Component<IGutterItemProps, any> {
             </div>
           )
         })}
-        {this.state.jiraIssues.map((issue) => {
+        {jiraIssues.map((issue) => {
           return (
             <div className="section">
               <div className="section-icon">

--- a/lib/data/IntegrationData.ts
+++ b/lib/data/IntegrationData.ts
@@ -5,6 +5,7 @@ import * as GitData from './GitData';
 import db from './database';
 import _ from 'lodash';
 import GitHelper from '../git/GitHelper';
+import * as IntegrationNotification from '../interface/IntegrationNotification';
 
 let pendingRequests = {};
 
@@ -65,6 +66,7 @@ async function processIntegrationData(data) {
       .push(toWrite)
       .write();
   }
+  IntegrationNotification.checkIntegrationDataRetrieved(pullRequests, githubIssues, jiraIssues);
   return db.get('pullRequests').value();
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,7 @@ import os from 'os';
 import * as ConfigManager from './ConfigManager';
 import * as ColorScale from './interface/ColourScale';
 import * as Analytics from './stepsize/Analytics';
+import * as IntegrationNotification from './interface/IntegrationNotification';
 
 let disposables = new CompositeDisposable();
 let outgoing: StepsizeOutgoing;
@@ -62,11 +63,13 @@ function toggleGutterView() {
       } else {
         Analytics.track('Gutter shown');
         gutter.show();
+        IntegrationNotification.handleGutterShown();
       }
     } else {
       Analytics.track('Gutter shown');
       gutters.set(editor, new GutterView(editor, outgoing));
       ColorScale.setEditor(editor);
+      IntegrationNotification.handleGutterShown();
     }
   }
 }

--- a/lib/interface/IntegrationNotification.ts
+++ b/lib/interface/IntegrationNotification.ts
@@ -1,0 +1,67 @@
+'use babel';
+
+import shell from 'shell';
+import * as Analytics from '../stepsize/Analytics';
+
+export function handleGutterShown() {
+  trackGutterShown();
+  showIntegrationNotificationIfAppropriate();
+}
+
+function trackGutterShown() {
+  const gutterShownCount = localStorage.getItem('better-git-blame-gutter-shown-count') || '0';
+  localStorage.setItem('better-git-blame-gutter-shown-count', `${parseInt(gutterShownCount, 10) + 1}`);
+}
+
+function showIntegrationNotificationIfAppropriate() {
+  const wasNotificationShown = localStorage.getItem('better-git-blame-integration-notification-shown');
+  if (wasNotificationShown === 'true') return;
+  const gutterShownCount = parseInt(localStorage.getItem('better-git-blame-gutter-shown-count') || '0', 10);
+  const tooltipShownCount = parseInt(localStorage.getItem('better-git-blame-tooltip-shown-count') || '0', 10);
+  const pullRequestCount = parseInt(localStorage.getItem('better-git-blame-pull-request-count') || '0', 10);
+  const issueCount = parseInt(localStorage.getItem('better-git-blame-issue-count') || '0', 10);
+  if (gutterShownCount >= 5 && tooltipShownCount >= 5 && pullRequestCount === 0 && issueCount === 0) {
+    Analytics.track('Integration notification shown');
+    showIntegrationNotification();
+    localStorage.setItem('better-git-blame-integration-notification-shown', 'true');
+  }
+}
+
+function showIntegrationNotification() {
+  atom.notifications.addInfo('Boss mode blame', {
+    description: 'Want to see pull requests and issues in `better-git-blame` popovers?\n\n<img src="https://i.imgur.com/vUTvxHv.png" width="400" height="172" />\n\nJust setup one of our integrations to level up 🔥',
+    dismissable: true,
+    buttons: [
+      {
+        text: 'GitHub integration',
+        onDidClick: () => {
+          Analytics.track('Integration notification GitHub clicked');
+          shell.openExternal('https://github.com/apps/layer');
+        },
+      },
+      {
+        text: 'Jira integration',
+        onDidClick: () => {
+          Analytics.track('Integration notification Jira clicked');
+          shell.openExternal('https://github.com/Stepsize/atom-better-git-blame#setup-the-jira-integration');
+        },
+      },
+      {
+        text: 'Tell me more',
+        onDidClick: () => {
+          Analytics.track('Integration notification more clicked');
+          shell.openExternal('https://github.com/Stepsize/atom-better-git-blame#how-do-i-get-setup');
+        },
+      },
+    ],
+  });
+}
+
+export function trackTooltipShown(pullRequestCount: number, issueCount: number) {
+  const tooltipShownCount = localStorage.getItem('better-git-blame-tooltip-shown-count') || '0';
+  localStorage.setItem('better-git-blame-tooltip-shown-count', `${parseInt(tooltipShownCount, 10) + 1}`);
+  const prCount = localStorage.getItem('better-git-blame-pull-request-count') || '0';
+  localStorage.setItem('better-git-blame-pull-request-count', `${parseInt(prCount, 10) + pullRequestCount}`);
+  const iCount = localStorage.getItem('better-git-blame-issue-count') || '0';
+  localStorage.setItem('better-git-blame-issue-count', `${parseInt(iCount, 10) + issueCount}`);
+}

--- a/lib/interface/IntegrationNotification.ts
+++ b/lib/interface/IntegrationNotification.ts
@@ -56,21 +56,21 @@ function showIntegrationNotification() {
       {
         text: 'GitHub integration',
         onDidClick: () => {
-          Analytics.track('Integration notification GitHub clicked');
+          Analytics.track('Integration notification button clicked', { type: 'github' });
           shell.openExternal('https://github.com/apps/layer');
         },
       },
       {
         text: 'Jira integration',
         onDidClick: () => {
-          Analytics.track('Integration notification Jira clicked');
+          Analytics.track('Integration notification button clicked', { type: 'jira' });
           shell.openExternal('https://github.com/Stepsize/atom-better-git-blame#setup-the-jira-integration');
         },
       },
       {
         text: 'Tell me more',
         onDidClick: () => {
-          Analytics.track('Integration notification more clicked');
+          Analytics.track('Integration notification button clicked', { type: 'more' });
           shell.openExternal('https://github.com/Stepsize/atom-better-git-blame#how-do-i-get-setup');
         },
       },


### PR DESCRIPTION
The plugin works best with the GitHub and/or Jira integrations set up (so it displays & uses information about PRs & issues), so we notify users when appropriate to let them know that the integrations exist. We only notify once.

When is appropriate?
- The user is familiar with the plugin – currently defined as >= 5 gutters toggled & popovers viewed
- The user likely does not have any of the integrations set up – currently defined as not a single PR or issue was displayed in the tooltips viewed by the user
- The user has not seen this notification before
- The user has just shown the gutter in a file (so we don't interrupt them in the middle of something)