### PR TITLE
Generate unique (and irreversible) ids to identify repos the plugin is used with so we can measure team usage

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,6 @@
 'use babel';
 
 import IEditor = AtomCore.IEditor;
-import IGutterView = AtomCore.IGutterView;
 import SelectionWatcher from './stepsize/SelectionWatcher';
 import StepsizeOutgoing from './stepsize/StepsizeOutgoing';
 import StepsizeHelper from './stepsize/StepsizeHelper';
@@ -11,11 +10,10 @@ import os from 'os';
 import * as ConfigManager from './ConfigManager';
 import * as ColorScale from './interface/ColourScale';
 import * as Analytics from './stepsize/Analytics';
-import * as IntegrationNotification from './interface/IntegrationNotification';
 
 let disposables = new CompositeDisposable();
 let outgoing: StepsizeOutgoing;
-let gutters: Map<IEditor, IGutterView> = new Map();
+let gutters: Map<IEditor, GutterView> = new Map();
 
 export const config = ConfigManager.getConfig();
 
@@ -57,19 +55,10 @@ function toggleGutterView() {
   if (editor) {
     const gutter = gutters.get(editor);
     if (gutter) {
-      if (gutter.isVisible()) {
-        Analytics.track('Gutter hidden');
-        gutter.hide();
-      } else {
-        Analytics.track('Gutter shown');
-        gutter.show();
-        IntegrationNotification.handleGutterShown();
-      }
+      gutter.toggle();
     } else {
-      Analytics.track('Gutter shown');
       gutters.set(editor, new GutterView(editor, outgoing));
       ColorScale.setEditor(editor);
-      IntegrationNotification.handleGutterShown();
     }
   }
 }

--- a/lib/interface/GutterView.ts
+++ b/lib/interface/GutterView.ts
@@ -16,6 +16,7 @@ import CodeSelector from '../stepsize/CodeSelector';
 import StepsizeOutgoing from '../stepsize/StepsizeOutgoing';
 import * as ConfigManager from '../ConfigManager';
 import * as Analytics from '../stepsize/Analytics';
+import * as IntegrationNotification from '../interface/IntegrationNotification';
 
 class GutterView {
   private editor: IEditor;
@@ -47,7 +48,20 @@ class GutterView {
         console.error(e);
       });
     this.codeSelector = new CodeSelector(this.editor);
-    return this.gutter;
+    Analytics.track('Gutter shown');
+    IntegrationNotification.handleGutterShown();
+    return this;
+  }
+
+  public toggle() {
+    if (this.gutter.isVisible()) {
+      this.gutter.hide();
+      Analytics.track('Gutter hidden');
+    } else {
+      this.gutter.show();
+      Analytics.track('Gutter shown');
+      IntegrationNotification.handleGutterShown();
+    }
   }
 
   private buildMarkersForRanges() {

--- a/lib/stepsize/Analytics.ts
+++ b/lib/stepsize/Analytics.ts
@@ -134,3 +134,21 @@ export function track(name, data = {}): void {
     });
   }
 }
+
+export interface IAnonymousRepoMetadata {
+  repoNameHash: string;
+  repoOwnerHash: string;
+  repoSourceHash: string;
+}
+export function anonymiseRepoMetadata(metadata: { [prop: string]: string }): IAnonymousRepoMetadata {
+  const anonymiseField = (field: string): string => {
+    const hash = crypto.createHash('sha256');
+    hash.update(field);
+    return hash.digest('hex');
+  };
+  return {
+    repoNameHash: anonymiseField(metadata.repoName),
+    repoOwnerHash: anonymiseField(metadata.repoOwner),
+    repoSourceHash: anonymiseField(metadata.repoSource),
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "skipLibCheck": true,
     "inlineSourceMap": true,
     "inlineSources": true,
+    "noImplicitAny": false,
     "strict": true,
     "target": "ES6"
   }


### PR DESCRIPTION
We want to be able to measure whether multiple users of the plugin are working on the same repos, to get a sense of whether the plugin spreads within a team (which is a proxy for word of mouth).

And we want to do this anonymously, so we generate SHA256 hashes of repo names, owners, and remotes.