### PR TITLE
Improve logic to check whether Layer is installed

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,7 +23,7 @@ export function activate(state) {
       'better-git-blame:toggle': () => toggleGutterView(),
     })
   );
-  if (os.platform() === 'darwin' && ConfigManager.get('searchInLayerEnabled')) {
+  if (os.platform() === 'darwin') {
     enableLayerSearch();
   } else {
     ConfigManager.set('searchInLayerEnabled', false);
@@ -42,6 +42,7 @@ async function layerEditorObserver(editor: IEditor) {
 function enableLayerSearch() {
   StepsizeHelper.checkLayerInstallation()
     .then(() => {
+      ConfigManager.set('searchInLayerEnabled', true);
       outgoing = new StepsizeOutgoing();
       atom.workspace.observeTextEditors(layerEditorObserver);
     })

--- a/lib/stepsize/StepsizeHelper.ts
+++ b/lib/stepsize/StepsizeHelper.ts
@@ -1,5 +1,6 @@
 'use babel';
 
+import os from 'os';
 import uuid from 'uuid-v4';
 import * as https from 'https';
 import * as childProcess from 'child_process';
@@ -67,6 +68,7 @@ class StepsizeHelper {
 
   public static checkLayerInstallation(): Promise<void> {
     return new Promise((resolve, reject) => {
+      if (os.platform() !== 'darwin') reject();
       const appSupport = `${process.env.HOME}/Library/Application Support`;
       childProcess.exec("ls | grep 'Layer'", { cwd: appSupport }, err => {
         if (err) {

--- a/lib/stepsize/StepsizeHelper.ts
+++ b/lib/stepsize/StepsizeHelper.ts
@@ -67,7 +67,8 @@ class StepsizeHelper {
 
   public static checkLayerInstallation(): Promise<void> {
     return new Promise((resolve, reject) => {
-      childProcess.exec("ls | grep 'Layer.app'", { cwd: '/Applications' }, err => {
+      const appSupport = `${process.env.HOME}/Library/Application Support`;
+      childProcess.exec("ls | grep 'Layer'", { cwd: appSupport }, err => {
         if (err) {
           return reject(new Error('Could not detect Layer installation'));
         }


### PR DESCRIPTION
Instead of looking for Layer in /Applications, we now look for the Layer Application Support directory in case the app has not been moved to /Applications (e.g. kept in ~/Downloads).

Also, we now check for the existence of Layer at every boot of the plugin so users who used the plugin before downloading Layer just have to reboot Atom once they get Layer to activate the communication.