### PR TITLE
Better 'Not Committed Yet' visualization

### DIFF
--- a/lib/components/GutterItem.tsx
+++ b/lib/components/GutterItem.tsx
@@ -115,6 +115,8 @@ class GutterItem extends React.Component<IGutterItemProps, any> {
     const date = commit.commitedAt;
     const formattedDate = moment(date).format(ConfigManager.get('gutterDateFormat'));
     let author = commit.author;
+    if (author == 'Not Committed Yet')
+      return `${author}`
     if(ConfigManager.get('truncateGutterNames')){
       const splitAuthor = author.split(' ');
       if(splitAuthor.length > 1){


### PR DESCRIPTION
Hello,
yesterday it took me almost two minutes to get who N. C Yet was, and after that I cringed a bit. So here it is what I think it might be an improvement:

|Before| After|
|--|--|
|<img width="272" alt="before - final" src="https://user-images.githubusercontent.com/6209647/40270688-f45d51d0-5b91-11e8-9d75-6b374575f9aa.png"> | <img width="302" alt="after - final" src="https://user-images.githubusercontent.com/6209647/40270687-f4393bba-5b91-11e8-9425-e71baf1beb9f.png">|

I removed the date since it always show the exact time that the blame command is called, and also I hard-coded ```Not Committed Yet``` since it is actually hard-coded in the very code of git (https://github.com/git/git/blob/69d71ec4433d21f464d83b529432856da2387bba/blame.c#L178).

I hope that's ok.